### PR TITLE
Add iter and from_repr support, switch to strum crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,11 @@ categories = ["embedded", "no-std", "encoding", "parsing"]
 rust-version = "1.61.0"
 
 [features]
-default = ["std", "display", "with-kwp2000", "with-obd2", "with-uds"]
+default = ["std", "iter", "display", "with-kwp2000", "with-obd2", "with-uds"]
 # Include support for std library. Without this feature, uses `no_std` attribute
 std = []
+# Add Enum::iter() implementation for all enums
+iter = []
 # Add Display implementation for all enums, using doc comments as display strings
 display = ["dep:displaydoc"]
 # Include support for Keyword protocol 2000 - ISO142330

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ with-obd2 = []
 with-uds = []
 
 [dependencies]
-enum2repr = "0.1"
 displaydoc = { version = "0.2", optional = true }
+strum = { version = "0.26.3", features = ["derive"] }
 
 [dev-dependencies]
 cargo-husky = { version = "1", features = ["user-hooks"], default-features = false }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pull request.
 ## Usage
 
 All values are presented as Rust `enum`, and can be converted to/from their underlying numeric values using
-the `From<T>` and `TryFrom<u8>` traits. Most enums also have a corresponding `...Byte` enums as `ByteWrapper<T>` to
+the `T::from_repr(u8)` and `u8::from(value)`. Most enums also have a corresponding `...Byte` enums as `ByteWrapper<T>` to
 handle the non-standard `Extended(u8)` values in addition to the defined `Standand(T)` ones.
 
 ```rust

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ clean:
 
 # Run cargo clippy
 clippy:
-    cargo clippy --bins --tests --lib --benches --examples -- -D warnings
+    cargo clippy --workspace --bins --tests --lib --benches --examples -- -D warnings
     cargo clippy --no-default-features -- -D warnings
 
 # Test code formatting

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ clean:
 # Run cargo clippy
 clippy:
     cargo clippy --workspace --bins --tests --lib --benches --examples -- -D warnings
-    cargo clippy --no-default-features -- -D warnings
+    cargo clippy --no-default-features --features with-uds -- -D warnings
 
 # Test code formatting
 test-fmt:
@@ -34,8 +34,9 @@ check:
 # Run all tests
 test:
     RUSTFLAGS='-D warnings' cargo test
+    RUSTFLAGS='-D warnings' cargo test --no-default-features --features with-kwp2000
+    RUSTFLAGS='-D warnings' cargo test --no-default-features --features with-obd2
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features with-uds
-    RUSTFLAGS='-D warnings' cargo test --no-default-features
 
 # Test documentation
 test-doc:

--- a/src/kwp2000/commands.rs
+++ b/src/kwp2000/commands.rs
@@ -1,5 +1,3 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
 
 /// KWP Command Service IDs.
@@ -7,7 +5,8 @@ crate::enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
 /// Note. This does not cover both the 'Reserved' range (0x87-0xB9) and
 /// 'System supplier specific' range (0xBA-0xBF)
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum KwpCommand {
     /// Start or change ECU diagnostic session mode.
     StartDiagnosticSession = 0x10,

--- a/src/kwp2000/commands.rs
+++ b/src/kwp2000/commands.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
+crate::utils::enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
 
 /// KWP Command Service IDs.
 ///

--- a/src/kwp2000/commands.rs
+++ b/src/kwp2000/commands.rs
@@ -1,15 +1,13 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
+crate::enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
 
 /// KWP Command Service IDs.
 ///
 /// Note. This does not cover both the 'Reserved' range (0x87-0xB9) and
 /// 'System supplier specific' range (0xBA-0xBF)
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum KwpCommand {
     /// Start or change ECU diagnostic session mode.
     StartDiagnosticSession = 0x10,

--- a/src/kwp2000/errors.rs
+++ b/src/kwp2000/errors.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(kwp2000, KwpError, KwpErrorByte);
 
 /// KWP2000 Error definitions
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum KwpError {
     /// ECU rejected the request for unknown reason
     GeneralReject = 0x10,

--- a/src/kwp2000/errors.rs
+++ b/src/kwp2000/errors.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(kwp2000, KwpError, KwpErrorByte);
+crate::utils::enum_wrapper!(kwp2000, KwpError, KwpErrorByte);
 
 /// KWP2000 Error definitions
 #[repr(u8)]

--- a/src/kwp2000/errors.rs
+++ b/src/kwp2000/errors.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(kwp2000, KwpError, KwpErrorByte);
+crate::enum_wrapper!(kwp2000, KwpError, KwpErrorByte);
 
 /// KWP2000 Error definitions
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum KwpError {
     /// ECU rejected the request for unknown reason
     GeneralReject = 0x10,

--- a/src/kwp2000/reset_types.rs
+++ b/src/kwp2000/reset_types.rs
@@ -1,6 +1,6 @@
 //! This service requests the ECU to perform a reset
 
-crate::enum_wrapper!(kwp2000, ResetType, ResetTypeByte);
+crate::utils::enum_wrapper!(kwp2000, ResetType, ResetTypeByte);
 
 /// ECU Reset types
 ///

--- a/src/kwp2000/reset_types.rs
+++ b/src/kwp2000/reset_types.rs
@@ -1,7 +1,5 @@
 //! This service requests the ECU to perform a reset
 
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(kwp2000, ResetType, ResetTypeByte);
 
 /// ECU Reset types
@@ -13,7 +11,8 @@ crate::enum_wrapper!(kwp2000, ResetType, ResetTypeByte);
 /// |[`ResetType::PowerOnReset`]|Mandatory|
 /// |[`ResetType::NonVolatileMemoryReset`]|Optional|
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum ResetType {
     /// Simulates a power off/on reset of the ECU.

--- a/src/kwp2000/reset_types.rs
+++ b/src/kwp2000/reset_types.rs
@@ -1,10 +1,8 @@
 //! This service requests the ECU to perform a reset
 
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(kwp2000, ResetType, ResetTypeByte);
+crate::enum_wrapper!(kwp2000, ResetType, ResetTypeByte);
 
 /// ECU Reset types
 ///
@@ -15,7 +13,7 @@ enum_wrapper!(kwp2000, ResetType, ResetTypeByte);
 /// |[`ResetType::PowerOnReset`]|Mandatory|
 /// |[`ResetType::NonVolatileMemoryReset`]|Optional|
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum ResetType {
     /// Simulates a power off/on reset of the ECU.

--- a/src/kwp2000/routine_exit_status.rs
+++ b/src/kwp2000/routine_exit_status.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(kwp2000, RoutineExitStatus, RoutineExitStatusByte);
+crate::utils::enum_wrapper!(kwp2000, RoutineExitStatus, RoutineExitStatusByte);
 
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/kwp2000/routine_exit_status.rs
+++ b/src/kwp2000/routine_exit_status.rs
@@ -1,11 +1,9 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(kwp2000, RoutineExitStatus, RoutineExitStatusByte);
+crate::enum_wrapper!(kwp2000, RoutineExitStatus, RoutineExitStatusByte);
 
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RoutineExitStatus {
     /// Normal exit with results available
     NormalExitWithResults = 0x61,

--- a/src/kwp2000/routine_exit_status.rs
+++ b/src/kwp2000/routine_exit_status.rs
@@ -1,9 +1,8 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(kwp2000, RoutineExitStatus, RoutineExitStatusByte);
 
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum RoutineExitStatus {
     /// Normal exit with results available
     NormalExitWithResults = 0x61,

--- a/src/kwp2000/session_types.rs
+++ b/src/kwp2000/session_types.rs
@@ -1,8 +1,6 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
+crate::enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
 
 /// KWP2000 diagnostic session type
 ///
@@ -16,7 +14,7 @@ enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
 /// |[`KwpSessionType::Passive`] | Optional (Only intended for ECU development) |
 /// |[`KwpSessionType::ExtendedDiagnostics`] | Mandatory |
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum KwpSessionType {
     /// Normal session. The ECU will typically boot in this state.
     /// In this mode, only non-intrusive functions are supported.

--- a/src/kwp2000/session_types.rs
+++ b/src/kwp2000/session_types.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
+crate::utils::enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
 
 /// KWP2000 diagnostic session type
 ///

--- a/src/kwp2000/session_types.rs
+++ b/src/kwp2000/session_types.rs
@@ -1,5 +1,3 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
 
 /// KWP2000 diagnostic session type
@@ -14,7 +12,8 @@ crate::enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
 /// |[`KwpSessionType::Passive`] | Optional (Only intended for ECU development) |
 /// |[`KwpSessionType::ExtendedDiagnostics`] | Mandatory |
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum KwpSessionType {
     /// Normal session. The ECU will typically boot in this state.
     /// In this mode, only non-intrusive functions are supported.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 #![cfg_attr(feature = "default", doc = include_str!("../README.md"))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// It makes no sense to use this crate without at least one of the core features enabled
+#[cfg(not(any(feature = "with-kwp2000", feature = "with-obd2", feature = "with-uds")))]
+compile_error!(
+    "At least one of the features `with-kwp2000`, `with-obd2`, or `with-uds` must be enabled!"
+);
+
 #[cfg(feature = "with-kwp2000")]
 pub mod kwp2000;
 #[cfg(feature = "with-obd2")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,14 @@ mod tests {
         use crate::ByteWrapper::{Extended, Standard};
 
         assert_eq!(UdsCommandByte::from(0x11), Standard(ECUReset));
+        assert_eq!(UdsCommand::from_repr(0x11), Some(ECUReset));
         assert_eq!(UdsCommand::try_from(0x11), Ok(ECUReset));
         assert_eq!(ECUReset as u8, 0x11);
         assert_eq!(u8::from(ECUReset), 0x11);
         assert_eq!(u8::from(Standard(ECUReset)), 0x11);
         assert_eq!(UdsCommandByte::from(ECUReset), Standard(ECUReset));
 
+        assert!(UdsCommand::from_repr(0x42).is_none());
         assert!(UdsCommand::try_from(0x42).is_err());
         assert_eq!(UdsCommandByte::from(0x42), Extended(0x42));
     }

--- a/src/obd2/command_2nd_air_status.rs
+++ b/src/obd2/command_2nd_air_status.rs
@@ -1,8 +1,6 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(
+crate::enum_wrapper!(
     obd2,
     CommandedSecondaryAirStatus,
     CommandedSecondaryAirStatusByte
@@ -10,7 +8,7 @@ enum_wrapper!(
 
 /// Commanded secondary air status for PID 12
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum CommandedSecondaryAirStatus {
     /// Upstream

--- a/src/obd2/command_2nd_air_status.rs
+++ b/src/obd2/command_2nd_air_status.rs
@@ -1,5 +1,3 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(
     obd2,
     CommandedSecondaryAirStatus,
@@ -8,7 +6,8 @@ crate::enum_wrapper!(
 
 /// Commanded secondary air status for PID 12
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum CommandedSecondaryAirStatus {
     /// Upstream

--- a/src/obd2/command_2nd_air_status.rs
+++ b/src/obd2/command_2nd_air_status.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(
+crate::utils::enum_wrapper!(
     obd2,
     CommandedSecondaryAirStatus,
     CommandedSecondaryAirStatusByte

--- a/src/obd2/commands.rs
+++ b/src/obd2/commands.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(obd2, Obd2Command, Obd2CommandByte);
+crate::utils::enum_wrapper!(obd2, Obd2Command, Obd2CommandByte);
 
 /// OBD2 Command Service IDs
 #[repr(u8)]

--- a/src/obd2/commands.rs
+++ b/src/obd2/commands.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(obd2, Obd2Command, Obd2CommandByte);
 
 /// OBD2 Command Service IDs
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum Obd2Command {
     /// Service 01 - Show current data

--- a/src/obd2/commands.rs
+++ b/src/obd2/commands.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(obd2, Obd2Command, Obd2CommandByte);
+crate::enum_wrapper!(obd2, Obd2Command, Obd2CommandByte);
 
 /// OBD2 Command Service IDs
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum Obd2Command {
     /// Service 01 - Show current data

--- a/src/obd2/data_pids.rs
+++ b/src/obd2/data_pids.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(obd2, DataPid, DataPidByte);
+crate::enum_wrapper!(obd2, DataPid, DataPidByte);
 
 /// OBD2 data PIDs used for Service 01 and 02
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DataPid {
     PidSupport0120 = 0x00,
     StatusSinceDTCCleared = 0x01,

--- a/src/obd2/data_pids.rs
+++ b/src/obd2/data_pids.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(obd2, DataPid, DataPidByte);
 
 /// OBD2 data PIDs used for Service 01 and 02
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum DataPid {
     PidSupport0120 = 0x00,
     StatusSinceDTCCleared = 0x01,

--- a/src/obd2/data_pids.rs
+++ b/src/obd2/data_pids.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(obd2, DataPid, DataPidByte);
+crate::utils::enum_wrapper!(obd2, DataPid, DataPidByte);
 
 /// OBD2 data PIDs used for Service 01 and 02
 #[repr(u8)]

--- a/src/obd2/errors.rs
+++ b/src/obd2/errors.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte);
+crate::enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte);
 
 /// OBD2 Error definitions
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum Obd2Error {
     /// ECU general reject

--- a/src/obd2/errors.rs
+++ b/src/obd2/errors.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte);
 
 /// OBD2 Error definitions
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum Obd2Error {
     /// ECU general reject

--- a/src/obd2/errors.rs
+++ b/src/obd2/errors.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte);
+crate::utils::enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte);
 
 /// OBD2 Error definitions
 #[repr(u8)]

--- a/src/obd2/fuel_system_status.rs
+++ b/src/obd2/fuel_system_status.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte);
+crate::enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte);
 
 /// Fuel system status enumeration for PID 03
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum FuelSystemStatus {
     /// The motor is off

--- a/src/obd2/fuel_system_status.rs
+++ b/src/obd2/fuel_system_status.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte);
+crate::utils::enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte);
 
 /// Fuel system status enumeration for PID 03
 #[repr(u8)]

--- a/src/obd2/fuel_system_status.rs
+++ b/src/obd2/fuel_system_status.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte);
 
 /// Fuel system status enumeration for PID 03
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum FuelSystemStatus {
     /// The motor is off

--- a/src/obd2/fuel_types.rs
+++ b/src/obd2/fuel_types.rs
@@ -1,13 +1,11 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte);
+crate::enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte);
 
 /// Fuel type coding for PID 51
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum FuelTypeCoding {
     /// Fuel type unavailable

--- a/src/obd2/fuel_types.rs
+++ b/src/obd2/fuel_types.rs
@@ -1,11 +1,10 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte);
 
 /// Fuel type coding for PID 51
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum FuelTypeCoding {
     /// Fuel type unavailable

--- a/src/obd2/fuel_types.rs
+++ b/src/obd2/fuel_types.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte);
+crate::utils::enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte);
 
 /// Fuel type coding for PID 51
 #[allow(non_camel_case_types)]

--- a/src/obd2/obd_standard.rs
+++ b/src/obd2/obd_standard.rs
@@ -1,13 +1,11 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(obd2, ObdStandard, ObdStandardByte);
+crate::enum_wrapper!(obd2, ObdStandard, ObdStandardByte);
 
 /// OBD Standard for PID 1C
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[allow(clippy::doc_markdown)]
 pub enum ObdStandard {

--- a/src/obd2/obd_standard.rs
+++ b/src/obd2/obd_standard.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(obd2, ObdStandard, ObdStandardByte);
+crate::utils::enum_wrapper!(obd2, ObdStandard, ObdStandardByte);
 
 /// OBD Standard for PID 1C
 #[allow(non_camel_case_types)]

--- a/src/obd2/obd_standard.rs
+++ b/src/obd2/obd_standard.rs
@@ -1,11 +1,10 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(obd2, ObdStandard, ObdStandardByte);
 
 /// OBD Standard for PID 1C
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[allow(clippy::doc_markdown)]
 pub enum ObdStandard {

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(obd2, Service09Pid, Service09PidByte);
+crate::utils::enum_wrapper!(obd2, Service09Pid, Service09PidByte);
 
 /// OBD2 service 09 (Request vehicle information) PIDs
 #[repr(u8)]

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(obd2, Service09Pid, Service09PidByte);
+crate::enum_wrapper!(obd2, Service09Pid, Service09PidByte);
 
 /// OBD2 service 09 (Request vehicle information) PIDs
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum Service09Pid {
     /// VIN message count (Only for LIN)

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(obd2, Service09Pid, Service09PidByte);
 
 /// OBD2 service 09 (Request vehicle information) PIDs
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum Service09Pid {
     /// VIN message count (Only for LIN)

--- a/src/uds/comm_level.rs
+++ b/src/uds/comm_level.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(uds, CommunicationLevel, CommunicationLevelByte);
+crate::enum_wrapper!(uds, CommunicationLevel, CommunicationLevelByte);
 
 /// Communication level toggle
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CommunicationLevel {
     /// This value indicates that the reception and transmission of messages
     /// shall be enabled for the specified communicationType.

--- a/src/uds/comm_level.rs
+++ b/src/uds/comm_level.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(uds, CommunicationLevel, CommunicationLevelByte);
 
 /// Communication level toggle
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum CommunicationLevel {
     /// This value indicates that the reception and transmission of messages
     /// shall be enabled for the specified communicationType.

--- a/src/uds/comm_level.rs
+++ b/src/uds/comm_level.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(uds, CommunicationLevel, CommunicationLevelByte);
+crate::utils::enum_wrapper!(uds, CommunicationLevel, CommunicationLevelByte);
 
 /// Communication level toggle
 #[repr(u8)]

--- a/src/uds/commands.rs
+++ b/src/uds/commands.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(uds, UdsCommand, UdsCommandByte);
 
 /// UDS Command Service IDs
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum UdsCommand {
     /// The client requests to control a diagnostic session with a server(s).

--- a/src/uds/commands.rs
+++ b/src/uds/commands.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(uds, UdsCommand, UdsCommandByte);
+crate::enum_wrapper!(uds, UdsCommand, UdsCommandByte);
 
 /// UDS Command Service IDs
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum UdsCommand {
     /// The client requests to control a diagnostic session with a server(s).

--- a/src/uds/commands.rs
+++ b/src/uds/commands.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(uds, UdsCommand, UdsCommandByte);
+crate::utils::enum_wrapper!(uds, UdsCommand, UdsCommandByte);
 
 /// UDS Command Service IDs
 #[repr(u8)]

--- a/src/uds/errors.rs
+++ b/src/uds/errors.rs
@@ -1,6 +1,6 @@
-use crate::enum_wrapper;
 #[cfg(doc)]
 use crate::uds::SecurityOperation;
+use crate::utils::enum_wrapper;
 
 enum_wrapper!(uds, UdsError, UdsErrorByte);
 

--- a/src/uds/errors.rs
+++ b/src/uds/errors.rs
@@ -1,4 +1,4 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
 use crate::enum_wrapper;
 #[cfg(doc)]
@@ -8,7 +8,7 @@ enum_wrapper!(uds, UdsError, UdsErrorByte);
 
 /// UDS Error definitions
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UdsError {
     /// ECU rejected the request (No specific error)
     GeneralReject = 0x10,

--- a/src/uds/errors.rs
+++ b/src/uds/errors.rs
@@ -1,5 +1,3 @@
-use strum::{EnumIter, FromRepr};
-
 use crate::enum_wrapper;
 #[cfg(doc)]
 use crate::uds::SecurityOperation;
@@ -8,7 +6,8 @@ enum_wrapper!(uds, UdsError, UdsErrorByte);
 
 /// UDS Error definitions
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum UdsError {
     /// ECU rejected the request (No specific error)
     GeneralReject = 0x10,

--- a/src/uds/read_dtc_information.rs
+++ b/src/uds/read_dtc_information.rs
@@ -1,5 +1,3 @@
-use strum::{EnumIter, FromRepr};
-
 use crate::enum_wrapper;
 #[cfg(doc)]
 use crate::uds::UdsCommand;
@@ -8,7 +6,8 @@ enum_wrapper!(uds, DtcSubFunction, DtcSubFunctionByte);
 
 /// [`UdsCommand::ReadDTCInformation`] sub-function definitions
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[allow(clippy::doc_markdown)]
 pub enum DtcSubFunction {

--- a/src/uds/read_dtc_information.rs
+++ b/src/uds/read_dtc_information.rs
@@ -1,4 +1,4 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
 use crate::enum_wrapper;
 #[cfg(doc)]
@@ -8,7 +8,7 @@ enum_wrapper!(uds, DtcSubFunction, DtcSubFunctionByte);
 
 /// [`UdsCommand::ReadDTCInformation`] sub-function definitions
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[allow(clippy::doc_markdown)]
 pub enum DtcSubFunction {

--- a/src/uds/read_dtc_information.rs
+++ b/src/uds/read_dtc_information.rs
@@ -1,6 +1,6 @@
-use crate::enum_wrapper;
 #[cfg(doc)]
 use crate::uds::UdsCommand;
+use crate::utils::enum_wrapper;
 
 enum_wrapper!(uds, DtcSubFunction, DtcSubFunctionByte);
 

--- a/src/uds/reset_types.rs
+++ b/src/uds/reset_types.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(uds, ResetType, ResetTypeByte);
 
 /// Reset ECU subcommand
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum ResetType {
     /// Signals the ECU to perform a hard-reset,
     /// simulating a forceful power off/on cycle

--- a/src/uds/reset_types.rs
+++ b/src/uds/reset_types.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(uds, ResetType, ResetTypeByte);
+crate::utils::enum_wrapper!(uds, ResetType, ResetTypeByte);
 
 /// Reset ECU subcommand
 #[repr(u8)]

--- a/src/uds/reset_types.rs
+++ b/src/uds/reset_types.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(uds, ResetType, ResetTypeByte);
+crate::enum_wrapper!(uds, ResetType, ResetTypeByte);
 
 /// Reset ECU subcommand
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ResetType {
     /// Signals the ECU to perform a hard-reset,
     /// simulating a forceful power off/on cycle

--- a/src/uds/routine.rs
+++ b/src/uds/routine.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
+crate::utils::enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
 
 /// UDS Routine (0x31) service control types.
 /// See chapter `14.2 RoutineControl service` in the ISO 14229 spec.

--- a/src/uds/routine.rs
+++ b/src/uds/routine.rs
@@ -1,11 +1,10 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
 
 /// UDS Routine (0x31) service control types.
 /// See chapter `14.2 RoutineControl service` in the ISO 14229 spec.
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum RoutineControlType {
     /// Launches a routine on the ECU
     StartRoutine = 0x01,

--- a/src/uds/routine.rs
+++ b/src/uds/routine.rs
@@ -1,13 +1,11 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
+crate::enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
 
 /// UDS Routine (0x31) service control types.
 /// See chapter `14.2 RoutineControl service` in the ISO 14229 spec.
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RoutineControlType {
     /// Launches a routine on the ECU
     StartRoutine = 0x01,

--- a/src/uds/scaling_byte.rs
+++ b/src/uds/scaling_byte.rs
@@ -1,11 +1,10 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_byte_wrapper!(uds, Scaling, ScalingByte);
 crate::enum_impls!(uds, ScalingType);
 
 /// Scaling high nibble, representing the type of data without its size. The size is given by the low nibble.
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum ScalingType {
     /// Unsigned numeric integer. Must be followed by 1..4 bytes, given as a low nibble of the byte.

--- a/src/uds/scaling_byte.rs
+++ b/src/uds/scaling_byte.rs
@@ -1,12 +1,11 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(uds, Scaling, ScalingByte);
+crate::enum_byte_wrapper!(uds, Scaling, ScalingByte);
+crate::enum_impls!(uds, ScalingType);
 
 /// Scaling high nibble, representing the type of data without its size. The size is given by the low nibble.
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum ScalingType {
     /// Unsigned numeric integer. Must be followed by 1..4 bytes, given as a low nibble of the byte.
@@ -44,7 +43,7 @@ pub struct Scaling {
 
 impl From<Scaling> for u8 {
     fn from(value: Scaling) -> Self {
-        value.typ as u8 | value.size
+        value.typ as Self | value.size
     }
 }
 
@@ -54,6 +53,12 @@ impl Scaling {
             return Err("Invalid size, expecting between 0 and 15.");
         }
         (typ as u8 | size).try_into()
+    }
+
+    /// Try to create [Self] from the raw representation
+    #[must_use]
+    pub fn from_repr(discriminant: u8) -> Option<Self> {
+        Scaling::try_from(discriminant).ok()
     }
 }
 

--- a/src/uds/scaling_byte.rs
+++ b/src/uds/scaling_byte.rs
@@ -1,5 +1,5 @@
-crate::enum_byte_wrapper!(uds, Scaling, ScalingByte);
-crate::enum_impls!(uds, ScalingType);
+crate::utils::enum_byte_wrapper!(uds, Scaling, ScalingByte);
+crate::utils::enum_impls!(uds, ScalingType);
 
 /// Scaling high nibble, representing the type of data without its size. The size is given by the low nibble.
 #[repr(u8)]

--- a/src/uds/scaling_byte_ext.rs
+++ b/src/uds/scaling_byte_ext.rs
@@ -1,5 +1,3 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(uds, ScalingExtension, ScalingExtensionByte);
 
 /// A macro rule to generate prefix and postfix functions from a single enum
@@ -64,7 +62,8 @@ generate_enum! {
     /// Use [`ScalingExtension::get_postfix`] to return the optional postfix of the scaling byte,
     /// or [`ScalingExtension::get_prefix`] to return the optional prefix of the scaling byte.
     #[repr(u8)]
-    #[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
     pub enum ScalingExtension {
         /// No unit or presentation
         NoUnit = 0x00,

--- a/src/uds/scaling_byte_ext.rs
+++ b/src/uds/scaling_byte_ext.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(uds, ScalingExtension, ScalingExtensionByte);
+crate::utils::enum_wrapper!(uds, ScalingExtension, ScalingExtensionByte);
 
 /// A macro rule to generate prefix and postfix functions from a single enum
 macro_rules! generate_enum {

--- a/src/uds/scaling_byte_ext.rs
+++ b/src/uds/scaling_byte_ext.rs
@@ -1,8 +1,6 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(uds, ScalingExtension, ScalingExtensionByte);
+crate::enum_wrapper!(uds, ScalingExtension, ScalingExtensionByte);
 
 /// A macro rule to generate prefix and postfix functions from a single enum
 macro_rules! generate_enum {
@@ -66,7 +64,7 @@ generate_enum! {
     /// Use [`ScalingExtension::get_postfix`] to return the optional postfix of the scaling byte,
     /// or [`ScalingExtension::get_prefix`] to return the optional prefix of the scaling byte.
     #[repr(u8)]
-    #[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
     pub enum ScalingExtension {
         /// No unit or presentation
         NoUnit = 0x00,

--- a/src/uds/security_access.rs
+++ b/src/uds/security_access.rs
@@ -3,13 +3,12 @@
 //!
 //! Currently, only default seed/key (0x01/0x02) are supported
 
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(uds, SecurityOperation, SecurityOperationByte);
 
 /// Security operation request
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum SecurityOperation {
     /// Asks the ECU for a security seed
     RequestSeed = 0x01,

--- a/src/uds/security_access.rs
+++ b/src/uds/security_access.rs
@@ -3,15 +3,13 @@
 //!
 //! Currently, only default seed/key (0x01/0x02) are supported
 
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(uds, SecurityOperation, SecurityOperationByte);
+crate::enum_wrapper!(uds, SecurityOperation, SecurityOperationByte);
 
 /// Security operation request
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SecurityOperation {
     /// Asks the ECU for a security seed
     RequestSeed = 0x01,

--- a/src/uds/security_access.rs
+++ b/src/uds/security_access.rs
@@ -3,7 +3,7 @@
 //!
 //! Currently, only default seed/key (0x01/0x02) are supported
 
-crate::enum_wrapper!(uds, SecurityOperation, SecurityOperationByte);
+crate::utils::enum_wrapper!(uds, SecurityOperation, SecurityOperationByte);
 
 /// Security operation request
 #[repr(u8)]

--- a/src/uds/session_types.rs
+++ b/src/uds/session_types.rs
@@ -1,12 +1,10 @@
-use enum2repr::EnumRepr;
+use strum::{EnumIter, FromRepr};
 
-use crate::enum_wrapper;
-
-enum_wrapper!(uds, UdsSessionType, UdsSessionTypeByte);
+crate::enum_wrapper!(uds, UdsSessionType, UdsSessionTypeByte);
 
 /// UDS Diagnostic session modes. Handled by SID 0x10
 #[repr(u8)]
-#[derive(EnumRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UdsSessionType {
     /// Default diagnostic session mode (ECU is normally in this mode on startup)
     /// This session type does not require the diagnostic server to sent `TesterPresent` messages

--- a/src/uds/session_types.rs
+++ b/src/uds/session_types.rs
@@ -1,10 +1,9 @@
-use strum::{EnumIter, FromRepr};
-
 crate::enum_wrapper!(uds, UdsSessionType, UdsSessionTypeByte);
 
 /// UDS Diagnostic session modes. Handled by SID 0x10
 #[repr(u8)]
-#[derive(FromRepr, EnumIter, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 pub enum UdsSessionType {
     /// Default diagnostic session mode (ECU is normally in this mode on startup)
     /// This session type does not require the diagnostic server to sent `TesterPresent` messages

--- a/src/uds/session_types.rs
+++ b/src/uds/session_types.rs
@@ -1,4 +1,4 @@
-crate::enum_wrapper!(uds, UdsSessionType, UdsSessionTypeByte);
+crate::utils::enum_wrapper!(uds, UdsSessionType, UdsSessionTypeByte);
 
 /// UDS Diagnostic session modes. Handled by SID 0x10
 #[repr(u8)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -65,8 +65,6 @@ macro_rules! enum_impls {
 
         #[cfg(test)]
         mod enum_impls_tests {
-            use ::strum::IntoEnumIterator as _;
-
             #[test]
             fn test_try_from() {
                 for value in 0x00_u8..=0xFF {
@@ -83,7 +81,10 @@ macro_rules! enum_impls {
             }
 
             #[test]
+            #[cfg(feature = "iter")]
             fn test_iter() {
+                use ::strum::IntoEnumIterator as _;
+
                 assert_ne!(0, $crate::$ns::$enum_name::iter().count());
                 for value in $crate::$ns::$enum_name::iter() {
                     let enc: u8 = value.into();


### PR DESCRIPTION
* Add `from_repr(u8) -> Option<Enum>` to all `Enum`s
  * this is a better method than `try_from` because `Option<T>` is likely to be smaller than `Result<T, &str>`
* Add `Enum::iter()` - enabled by default with the `iter` feature
* Switch to [strum crate](https://crates.io/crates/strum)
* Do not expose internal macros
* Fail to compile if none of the `with-kwp2000`, `with-obd2`, or `with-uds` features are enabled.