### PR TITLE
Deprecate `with-*` features. Use names directly.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
       #############################################################
       ## Full test
       ##
+      - uses: actions/checkout@v4
       - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with: { tool: 'just,cargo-llvm-cov' }
-      - uses: actions/checkout@v4
       - if: github.event_name == 'release'
         name: Ensure this crate has not yet been published (on release)
         run: just check-if-published

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automotive_diag"
-version = "0.1.11"
+version = "0.1.12"
 description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330) and OBD-II (ISO-9141) definitions to communicate with the road vehicle ECUs in Rust."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "Ashcon Mohseninia <ashconm@outlook.com>"]
 repository = "https://github.com/nyurik/automotive_diag"
@@ -11,7 +11,7 @@ categories = ["embedded", "no-std", "encoding", "parsing"]
 rust-version = "1.66"
 
 [features]
-default = ["std", "iter", "display", "with-kwp2000", "with-obd2", "with-uds"]
+default = ["std", "iter", "display", "kwp2000", "obd2", "uds"]
 # Include support for std library. Without this feature, uses `no_std` attribute
 std = []
 # Add Enum::iter() implementation for all enums
@@ -19,11 +19,14 @@ iter = []
 # Add Display implementation for all enums, using doc comments as display strings
 display = ["dep:displaydoc"]
 # Include support for Keyword protocol 2000 - ISO142330
-with-kwp2000 = []
+kwp2000 = []
+with-kwp2000 = ["kwp2000"] # deprecated, use `kwp2000` instead
 # Include support for On-board diagnostics
-with-obd2 = []
+obd2 = []
+with-obd2 = ["obd2"] # deprecated, use `obd2` instead
 # Include support for Unified Diagnostic Services
-with-uds = []
+uds = []
+with-uds = ["uds"] # deprecated, use `uds` instead
 # Include support for serde serialization
 serde = ["dep:serde"]
 
@@ -40,6 +43,8 @@ unsafe_code = "forbid"
 unused_qualifications = "warn"
 
 [lints.clippy]
+cargo = { level = "warn", priority = -1 }
+redundant_feature_names = "allow"  # with-* features have been deprecated. Remove this once they are removed
 pedantic = { level = "warn", priority = -1 }
 missing_errors_doc = "allow"
 module_name_repetitions = "allow"

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ msrv:
 # Run cargo clippy to lint the code
 clippy:
     cargo clippy --workspace --all-targets -- -D warnings
-    cargo clippy --no-default-features --features with-uds -- -D warnings
+    cargo clippy --no-default-features --features uds -- -D warnings
 
 # Test code formatting
 test-fmt:
@@ -53,7 +53,7 @@ docs:
 # Quick compile without building a binary
 check:
     RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
-    RUSTFLAGS='-D warnings' cargo check --no-default-features --features with-uds --all-targets
+    RUSTFLAGS='-D warnings' cargo check --no-default-features --features uds --all-targets
 
 # Generate code coverage report
 coverage *ARGS="--no-clean --open":
@@ -68,9 +68,9 @@ ci-coverage: && \
 # Run all tests
 test:
     RUSTFLAGS='-D warnings' cargo test --workspace --all-targets
-    RUSTFLAGS='-D warnings' cargo test --no-default-features --features with-kwp2000
-    RUSTFLAGS='-D warnings' cargo test --no-default-features --features with-obd2
-    RUSTFLAGS='-D warnings' cargo test --no-default-features --features with-uds
+    RUSTFLAGS='-D warnings' cargo test --no-default-features --features kwp2000
+    RUSTFLAGS='-D warnings' cargo test --no-default-features --features obd2
+    RUSTFLAGS='-D warnings' cargo test --no-default-features --features uds
     RUSTFLAGS='-D warnings' cargo test --features serde
 
 # Test documentation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,16 +2,14 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // It makes no sense to use this crate without at least one of the core features enabled
-#[cfg(not(any(feature = "with-kwp2000", feature = "with-obd2", feature = "with-uds")))]
-compile_error!(
-    "At least one of the features `with-kwp2000`, `with-obd2`, or `with-uds` must be enabled!"
-);
+#[cfg(not(any(feature = "kwp2000", feature = "obd2", feature = "uds")))]
+compile_error!("At least one of the features `kwp2000`, `obd2`, or `uds` must be enabled!");
 
-#[cfg(feature = "with-kwp2000")]
+#[cfg(feature = "kwp2000")]
 pub mod kwp2000;
-#[cfg(feature = "with-obd2")]
+#[cfg(feature = "obd2")]
 pub mod obd2;
-#[cfg(feature = "with-uds")]
+#[cfg(feature = "uds")]
 pub mod uds;
 
 mod utils;
@@ -21,7 +19,7 @@ pub use utils::ByteWrapper;
 mod tests {
 
     #[test]
-    #[cfg(feature = "with-uds")]
+    #[cfg(feature = "uds")]
     fn spot_test() {
         use crate::uds::UdsCommand::ECUReset;
         use crate::uds::{UdsCommand, UdsCommandByte};


### PR DESCRIPTION
This deprecates `with-uds`, `with-kwp2000`, and `with-obd2` features. Use `uds`, `kwp2000`, and `obd2`.