### PR TITLE
Add initial DoIP header types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "automotive_diag"
 version = "0.1.14"
-description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330) and OBD-II (ISO-9141) definitions to communicate with the road vehicle ECUs in Rust."
+description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330), OBD-II (ISO-9141), and DoIP (ISO-13400) definitions to communicate with the road vehicle ECUs in Rust."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "Ashcon Mohseninia <ashconm@outlook.com>"]
 repository = "https://github.com/nyurik/automotive_diag"
 edition = "2021"
@@ -11,7 +11,7 @@ categories = ["embedded", "no-std", "encoding", "parsing"]
 rust-version = "1.70"
 
 [features]
-default = ["std", "iter", "display", "kwp2000", "obd2", "uds"]
+default = ["std", "iter", "display", "doip", "kwp2000", "obd2", "uds"]
 # Include support for std library. Without this feature, uses `no_std` attribute
 std = ["strum/default"]
 # Add support for `defmt` logging
@@ -24,6 +24,8 @@ iter = []
 pyo3 = ["std", "dep:pyo3"]
 # Include support for serde serialization
 serde = ["dep:serde"]
+# Include support for DoIP - ISO-13400
+doip = []
 # Include support for Keyword protocol 2000 - ISO-142330
 kwp2000 = []
 with-kwp2000 = ["kwp2000"] # deprecated, use `kwp2000` instead

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 
 This crate provides low-level `no_std` structs and enums of
 the [Unified Diagnostic Services](https://en.wikipedia.org/wiki/Unified_Diagnostic_Services) (ISO-14229-1),
-[KWP2000](https://en.wikipedia.org/wiki/Keyword_Protocol_2000) (ISO-142330) and
+[KWP2000](https://en.wikipedia.org/wiki/Keyword_Protocol_2000) (ISO-142330),
 [OBD-II](https://en.wikipedia.org/wiki/On-board_diagnostics) (ISO-9141)
+and [DoIP](https://automotivevehicletesting.com/vehicle-diagnostics/doip/) (ISO-13400) diagnostic
 specifications for the road vehicles in Rust. Optionally supports `defmt`, `serde`, and `pyo3`. See features section in the `Cargo.toml` file.
 
 Most features have been implemented and documented to handle the most common diagnostic commands and responses.

--- a/justfile
+++ b/justfile
@@ -83,6 +83,7 @@ test:
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features kwp2000
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features obd2
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features uds
+    RUSTFLAGS='-D warnings' cargo test --no-default-features --features doip
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features defmt,iter,uds,obd2,kwp2000
     RUSTFLAGS='-D warnings' cargo test --features serde
     RUSTFLAGS='-D warnings' cargo test --features pyo3

--- a/src/doip/mod.rs
+++ b/src/doip/mod.rs
@@ -1,0 +1,7 @@
+//! Module for [Diagnostics over IP (`DoIP`)](https://automotivevehicletesting.com/vehicle-diagnostics/doip/) - ISO-13400
+
+mod payload_type;
+mod protocol_version;
+
+pub use payload_type::*;
+pub use protocol_version::*;

--- a/src/doip/payload_type.rs
+++ b/src/doip/payload_type.rs
@@ -1,0 +1,64 @@
+crate::utils::enum_impls!(doip, DoIpPayloadType, u16);
+crate::utils::assert_display_hash!(DoIpPayloadType, @"5886519332798079216");
+
+/// Defines the variants of payloads available to `DoIP`.
+///
+/// `DoIpPayloadType` values map to the `u16` representing the bytes it makes up
+/// within the `DoIP` packet.
+#[repr(u16)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+// TODO: should this be DoIp-prefixed?
+pub enum DoIpPayloadType {
+    /// Generic Negative Acknowledge
+    GenericNack = 0x0000,
+
+    /// Vehicle Identification Request
+    VehicleIdentificationRequest = 0x0001,
+
+    /// Vehicle Identification Request by EID
+    VehicleIdentificationRequestEid = 0x0002,
+
+    /// Vehicle Identification Request by VIN
+    VehicleIdentificationRequestVin = 0x0003,
+
+    /// Vehicle Announcement Message
+    VehicleAnnouncementMessage = 0x0004,
+
+    /// Routing Activation Request
+    RoutingActivationRequest = 0x0005,
+
+    /// Routing Activation Response
+    RoutingActivationResponse = 0x0006,
+
+    /// Alive Check Request
+    AliveCheckRequest = 0x0007,
+
+    /// Alive Check Response
+    AliveCheckResponse = 0x0008,
+
+    /// Entity Status Request
+    EntityStatusRequest = 0x4001,
+
+    /// Entity Status Response
+    EntityStatusResponse = 0x4002,
+
+    /// Power Information Request
+    PowerInformationRequest = 0x4003,
+
+    /// Power Information Response
+    PowerInformationResponse = 0x4004,
+
+    /// Diagnostic Message
+    DiagnosticMessage = 0x8001,
+
+    /// Diagnostic Message Acknowledgement
+    DiagnosticMessageAck = 0x8002,
+
+    /// Diagnostic Message Negative Acknowledgement
+    DiagnosticMessageNack = 0x8003,
+}

--- a/src/doip/payload_type.rs
+++ b/src/doip/payload_type.rs
@@ -1,9 +1,12 @@
-crate::utils::enum_impls!(doip, DoIpPayloadType, u16);
-crate::utils::assert_display_hash!(DoIpPayloadType, @"5886519332798079216");
+use crate::utils::{assert_display_hash, enum_impls, python_test};
+
+enum_impls!(doip, PayloadType, u16);
+assert_display_hash!(PayloadType, @"5886519332798079216");
+python_test!(doip, PayloadType, GenericNack, VehicleIdentificationRequest);
 
 /// Defines the variants of payloads available to `DoIP`.
 ///
-/// `DoIpPayloadType` values map to the `u16` representing the bytes it makes up
+/// `PayloadType` values map to the `u16` representing the bytes it makes up
 /// within the `DoIP` packet.
 #[repr(u16)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -12,8 +15,7 @@ crate::utils::assert_display_hash!(DoIpPayloadType, @"5886519332798079216");
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-// TODO: should this be DoIp-prefixed?
-pub enum DoIpPayloadType {
+pub enum PayloadType {
     /// Generic Negative Acknowledge
     GenericNack = 0x0000,
 

--- a/src/doip/protocol_version.rs
+++ b/src/doip/protocol_version.rs
@@ -1,8 +1,11 @@
-crate::utils::enum_wrapper!(
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(
     doip,
-    DoIpProtocolVersion,
-    DoIpProtocolVersionByte,
-    display = @"12259587059646726960");
+    ProtocolVersion,
+    ProtocolVersionByte,
+    display = @"15161726968649792658");
+python_test!(doip, ProtocolVersion, V2010, V2012);
 
 /// Available version of the `DoIP` protocol as per ISO-13400.
 ///
@@ -15,25 +18,24 @@ crate::utils::enum_wrapper!(
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-// TODO: should this be DoIp-prefixed?
-pub enum DoIpProtocolVersion {
+pub enum ProtocolVersion {
     // TODO: needed? This seems like a placeholder that shouldn't be used in Rust
     // /// Reserved Version
     // ReservedVer = 0x00,
     /// `DoIP` Payload Version: ISO-13400 2010 Version
-    Iso13400_2010 = 0x01,
+    V2010 = 0x01,
 
     /// `DoIP` Payload Version: ISO-13400 2012 Version
-    Iso13400_2012 = 0x02,
+    V2012 = 0x02,
 
     /// `DoIP` Payload Version: ISO-13400 2019 Version
-    Iso13400_2019 = 0x03,
+    V2019 = 0x03,
 
     /// `DoIP` Payload Version: ISO-13400 `2019_AMD1` Version
-    Iso13400_2019Amd1 = 0x04,
-
-    /// `DoIP` Payload Version: Default Version
-    DefaultValue = 0xFF,
+    V2019amd1 = 0x04,
+    // TODO: needed? This seems like a placeholder that shouldn't be used in Rust
+    // /// `DoIP` Payload Version: Default Version
+    // DefaultValue = 0xFF,
 }
 
 #[cfg(all(test, feature = "serde"))]
@@ -42,21 +44,21 @@ mod tests {
 
     #[derive(serde::Serialize, serde::Deserialize)]
     struct TestStruct {
-        command: DoIpProtocolVersion,
-        command_byte: DoIpProtocolVersionByte,
+        command: ProtocolVersion,
+        command_byte: ProtocolVersionByte,
     }
 
     #[test]
     fn test_serde() {
         let test = TestStruct {
-            command: DoIpProtocolVersion::Iso13400_2019,
-            command_byte: DoIpProtocolVersionByte::from(DoIpProtocolVersion::Iso13400_2019),
+            command: ProtocolVersion::V2019,
+            command_byte: ProtocolVersionByte::from(ProtocolVersion::V2019),
         };
 
         let json = serde_json::to_string(&test).unwrap();
         assert_eq!(
             json,
-            r#"{"command":"Iso13400_2019","command_byte":{"Standard":"Iso13400_2019"}}"#
+            r#"{"command":"V2019","command_byte":{"Standard":"V2019"}}"#
         );
 
         let deserialized: TestStruct = serde_json::from_str(&json).unwrap();

--- a/src/doip/protocol_version.rs
+++ b/src/doip/protocol_version.rs
@@ -1,0 +1,67 @@
+crate::utils::enum_wrapper!(
+    doip,
+    DoIpProtocolVersion,
+    DoIpProtocolVersionByte,
+    display = @"12259587059646726960");
+
+/// Available version of the `DoIP` protocol as per ISO-13400.
+///
+/// Maps to `u8` values for available `DoIP` protocols which are supported by this
+/// crate and ISO-13400.
+#[repr(u8)]
+#[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+// TODO: should this be DoIp-prefixed?
+pub enum DoIpProtocolVersion {
+    // TODO: needed? This seems like a placeholder that shouldn't be used in Rust
+    // /// Reserved Version
+    // ReservedVer = 0x00,
+    /// `DoIP` Payload Version: ISO-13400 2010 Version
+    Iso13400_2010 = 0x01,
+
+    /// `DoIP` Payload Version: ISO-13400 2012 Version
+    Iso13400_2012 = 0x02,
+
+    /// `DoIP` Payload Version: ISO-13400 2019 Version
+    Iso13400_2019 = 0x03,
+
+    /// `DoIP` Payload Version: ISO-13400 `2019_AMD1` Version
+    Iso13400_2019Amd1 = 0x04,
+
+    /// `DoIP` Payload Version: Default Version
+    DefaultValue = 0xFF,
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct TestStruct {
+        command: DoIpProtocolVersion,
+        command_byte: DoIpProtocolVersionByte,
+    }
+
+    #[test]
+    fn test_serde() {
+        let test = TestStruct {
+            command: DoIpProtocolVersion::Iso13400_2019,
+            command_byte: DoIpProtocolVersionByte::from(DoIpProtocolVersion::Iso13400_2019),
+        };
+
+        let json = serde_json::to_string(&test).unwrap();
+        assert_eq!(
+            json,
+            r#"{"command":"Iso13400_2019","command_byte":{"Standard":"Iso13400_2019"}}"#
+        );
+
+        let deserialized: TestStruct = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(test.command, deserialized.command);
+        assert_eq!(test.command_byte, deserialized.command_byte);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,16 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // It makes no sense to use this crate without at least one of the core features enabled
-#[cfg(not(any(feature = "kwp2000", feature = "obd2", feature = "uds")))]
-compile_error!("At least one of the features `kwp2000`, `obd2`, or `uds` must be enabled!");
+#[cfg(not(any(
+    feature = "doip",
+    feature = "kwp2000",
+    feature = "obd2",
+    feature = "uds",
+)))]
+compile_error!("At least one of the features `doip`, `kwp2000`, `obd2`, or `uds` must be enabled!");
 
+#[cfg(feature = "doip")]
+pub mod doip;
 #[cfg(feature = "kwp2000")]
 pub mod kwp2000;
 #[cfg(feature = "obd2")]


### PR DESCRIPTION
Adds two new enum types for the DoIP protocol.

CC: @samp-reston

### TODO:
* [x] Decide if `DoIp` prefix is needed for the new types
* [x] Decide if `DoIpPayloadType` really needs to be u16, or if it can be represented with multiple enums - one byte each.
* [x] Decide/implement python support - probably for all existing types as well.

### Credits
This was adapted from the https://github.com/samp-reston/doip-definitions repo with the owner's permission as part of the consolidation efforts.