### PR TITLE
Add `defmt` formatting support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["uds", "kwp2000", "obd", "automotive", "no_std"]
 categories = ["embedded", "no-std", "encoding", "parsing"]
-rust-version = "1.66"
+rust-version = "1.70"
 
 [features]
 default = ["std", "iter", "display", "kwp2000", "obd2", "uds"]
@@ -16,7 +16,9 @@ default = ["std", "iter", "display", "kwp2000", "obd2", "uds"]
 std = ["strum/default"]
 # Add Enum::iter() implementation for all enums
 iter = []
-# Add Display implementation for all enums, using doc comments as display strings
+# Add support for `defmt` logging
+defmt = ["dep:defmt"]
+# Add Display trait for all enums, using doc comments as display strings. Requires `std`.
 display = ["std", "dep:displaydoc"]
 # Include support for Keyword protocol 2000 - ISO-142330
 kwp2000 = []
@@ -31,6 +33,7 @@ with-uds = ["uds"] # deprecated, use `uds` instead
 serde = ["dep:serde"]
 
 [dependencies]
+defmt = { version = "1.0.1", optional = true }
 displaydoc = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 strum = { version = "0.27.0", default-features = false, features = ["derive"] }

--- a/justfile
+++ b/justfile
@@ -25,7 +25,7 @@ semver *ARGS:
 
 # Find the minimum supported Rust version (MSRV) using cargo-msrv extension, and update Cargo.toml
 msrv:
-    cargo msrv find --write-msrv --ignore-lockfile
+    cargo msrv find --write-msrv --ignore-lockfile --all-features
 
 # Get the minimum supported Rust version (MSRV) for the crate
 get-msrv: (get-crate-field "rust_version")
@@ -83,6 +83,7 @@ test:
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features kwp2000
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features obd2
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features uds
+    RUSTFLAGS='-D warnings' cargo test --no-default-features --features defmt,iter,uds,obd2,kwp2000
     RUSTFLAGS='-D warnings' cargo test --features serde
 
 # Test documentation

--- a/src/kwp2000/commands.rs
+++ b/src/kwp2000/commands.rs
@@ -6,6 +6,7 @@ crate::utils::enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
 /// 'System supplier specific' range (0xBA-0xBF)
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum KwpCommand {

--- a/src/kwp2000/errors.rs
+++ b/src/kwp2000/errors.rs
@@ -3,6 +3,7 @@ crate::utils::enum_wrapper!(kwp2000, KwpError, KwpErrorByte);
 /// KWP2000 Error definitions
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum KwpError {

--- a/src/kwp2000/reset_types.rs
+++ b/src/kwp2000/reset_types.rs
@@ -12,8 +12,9 @@ crate::utils::enum_wrapper!(kwp2000, ResetType, ResetTypeByte, display = @"15739
 /// |[`ResetType::NonVolatileMemoryReset`]|Optional|
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ResetType {
     /// Simulates a power off/on reset of the ECU.

--- a/src/kwp2000/routine_exit_status.rs
+++ b/src/kwp2000/routine_exit_status.rs
@@ -2,6 +2,7 @@ crate::utils::enum_wrapper!(kwp2000, RoutineExitStatus, RoutineExitStatusByte);
 
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::enum_variant_names)]

--- a/src/kwp2000/session_types.rs
+++ b/src/kwp2000/session_types.rs
@@ -13,6 +13,7 @@ crate::utils::enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
 /// |[`KwpSessionType::ExtendedDiagnostics`] | Mandatory |
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum KwpSessionType {

--- a/src/obd2/command_2nd_air_status.rs
+++ b/src/obd2/command_2nd_air_status.rs
@@ -8,8 +8,9 @@ crate::utils::enum_wrapper!(
 /// Commanded secondary air status for PID 12
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CommandedSecondaryAirStatus {
     /// Upstream

--- a/src/obd2/commands.rs
+++ b/src/obd2/commands.rs
@@ -3,8 +3,9 @@ crate::utils::enum_wrapper!(obd2, Obd2Command, Obd2CommandByte, display = @"2002
 /// OBD2 Command Service IDs
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Obd2Command {
     /// Service 01 - Show current data

--- a/src/obd2/data_pids.rs
+++ b/src/obd2/data_pids.rs
@@ -3,6 +3,7 @@ crate::utils::enum_wrapper!(obd2, DataPid, DataPidByte);
 /// OBD2 data PIDs used for Service 01 and 02
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DataPid {

--- a/src/obd2/errors.rs
+++ b/src/obd2/errors.rs
@@ -3,8 +3,9 @@ crate::utils::enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte, display = @"58362401
 /// OBD2 Error definitions
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Obd2Error {
     /// ECU general reject

--- a/src/obd2/fuel_system_status.rs
+++ b/src/obd2/fuel_system_status.rs
@@ -3,8 +3,9 @@ crate::utils::enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte, displa
 /// Fuel system status enumeration for PID 03
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FuelSystemStatus {
     /// The motor is off

--- a/src/obd2/fuel_types.rs
+++ b/src/obd2/fuel_types.rs
@@ -4,8 +4,9 @@ crate::utils::enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte, display = 
 #[allow(non_camel_case_types)]
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::upper_case_acronyms)]
 pub enum FuelTypeCoding {

--- a/src/obd2/obd_standard.rs
+++ b/src/obd2/obd_standard.rs
@@ -4,8 +4,9 @@ crate::utils::enum_wrapper!(obd2, ObdStandard, ObdStandardByte, display = @"1638
 #[allow(non_camel_case_types)]
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::doc_markdown, clippy::upper_case_acronyms)]
 pub enum ObdStandard {

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -3,8 +3,9 @@ crate::utils::enum_wrapper!(obd2, Service09Pid, Service09PidByte, display = @"79
 /// OBD2 service 09 (Request vehicle information) PIDs
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Service09Pid {
     /// VIN message count (Only for LIN)

--- a/src/uds/comm_control.rs
+++ b/src/uds/comm_control.rs
@@ -1,5 +1,6 @@
 /// ECU Communication types
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum CommunicationType {
     /// Application layer communication (inter-signal exchanges) between ECUs
@@ -12,6 +13,7 @@ pub enum CommunicationType {
 
 /// ECU communication subnet type
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 pub enum Subnet {
     /// All subnets

--- a/src/uds/comm_level.rs
+++ b/src/uds/comm_level.rs
@@ -3,6 +3,7 @@ crate::utils::enum_wrapper!(uds, CommunicationLevel, CommunicationLevelByte);
 /// Communication level toggle
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CommunicationLevel {

--- a/src/uds/commands.rs
+++ b/src/uds/commands.rs
@@ -3,8 +3,9 @@ crate::utils::enum_wrapper!(uds, UdsCommand, UdsCommandByte, display = @"1011110
 /// UDS Command Service IDs
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UdsCommand {
     /// The client requests to control a diagnostic session with a server(s).

--- a/src/uds/errors.rs
+++ b/src/uds/errors.rs
@@ -7,6 +7,7 @@ enum_wrapper!(uds, UdsError, UdsErrorByte);
 /// UDS Error definitions
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UdsError {

--- a/src/uds/read_dtc_information.rs
+++ b/src/uds/read_dtc_information.rs
@@ -7,8 +7,9 @@ enum_wrapper!(uds, DtcSubFunction, DtcSubFunctionByte, display = @"1013438647766
 /// [`UdsCommand::ReadDTCInformation`] sub-function definitions
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::doc_markdown, clippy::enum_variant_names)]
 pub enum DtcSubFunction {

--- a/src/uds/reset_types.rs
+++ b/src/uds/reset_types.rs
@@ -3,6 +3,7 @@ crate::utils::enum_wrapper!(uds, ResetType, ResetTypeByte);
 /// Reset ECU subcommand
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ResetType {

--- a/src/uds/routine.rs
+++ b/src/uds/routine.rs
@@ -4,6 +4,7 @@ crate::utils::enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
 /// See chapter `14.2 RoutineControl service` in the ISO 14229 spec.
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum RoutineControlType {

--- a/src/uds/scaling_byte.rs
+++ b/src/uds/scaling_byte.rs
@@ -4,8 +4,9 @@ crate::utils::enum_impls!(uds, ScalingType, u8);
 /// Scaling high nibble, representing the type of data without its size. The size is given by the low nibble.
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ScalingType {
     /// Unsigned numeric integer. Must be followed by 1..4 bytes, given as a low nibble of the byte.
@@ -36,6 +37,8 @@ pub enum ScalingType {
 
 /// Scaling value with both the [`ScalingType`] and the size of the data.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Scaling {
     typ: ScalingType,
     size: u8,

--- a/src/uds/security_access.rs
+++ b/src/uds/security_access.rs
@@ -8,6 +8,7 @@ crate::utils::enum_wrapper!(uds, SecurityOperation, SecurityOperationByte);
 /// Security operation request
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SecurityOperation {

--- a/src/uds/session_types.rs
+++ b/src/uds/session_types.rs
@@ -3,6 +3,7 @@ crate::utils::enum_wrapper!(uds, UdsSessionType, UdsSessionTypeByte);
 /// UDS Diagnostic session modes. Handled by SID 0x10
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UdsSessionType {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,6 +19,17 @@ impl<T: Debug> Debug for ByteWrapper<T> {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl<T: defmt::Format> defmt::Format for ByteWrapper<T> {
+    fn format(&self, fmt: defmt::Formatter) {
+        match self {
+            // For standard values, delegate to the Debug implementation of the inner type.
+            Self::Standard(v) => defmt::Format::format(v, fmt),
+            Self::Extended(v) => defmt::write!(fmt, "Extended({:#02X})", v),
+        }
+    }
+}
+
 impl<T: Into<u8>> From<ByteWrapper<T>> for u8 {
     fn from(value: ByteWrapper<T>) -> Self {
         match value {


### PR DESCRIPTION
Add `defmt::Format` trait to all enums when `defmt` feature is set.