### PR TITLE
Add optional python pyo3 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automotive_diag"
-version = "0.1.13"
+version = "0.1.14"
 description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330) and OBD-II (ISO-9141) definitions to communicate with the road vehicle ECUs in Rust."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "Ashcon Mohseninia <ashconm@outlook.com>"]
 repository = "https://github.com/nyurik/automotive_diag"
@@ -31,12 +31,15 @@ uds = []
 with-uds = ["uds"] # deprecated, use `uds` instead
 # Include support for serde serialization
 serde = ["dep:serde"]
+# Generate Python bindings for enums using pyo3. Requires std.
+pyo3 = ["std", "dep:pyo3"]
 
 [dependencies]
 defmt = { version = "1.0.1", optional = true }
 displaydoc = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 strum = { version = "0.27.0", default-features = false, features = ["derive"] }
+pyo3 = { version = "0.25.0", optional = true }
 
 [dev-dependencies]
 insta = "1.43.1"

--- a/justfile
+++ b/justfile
@@ -85,6 +85,8 @@ test:
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features uds
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features defmt,iter,uds,obd2,kwp2000
     RUSTFLAGS='-D warnings' cargo test --features serde
+    RUSTFLAGS='-D warnings' cargo test --features pyo3
+    RUSTFLAGS='-D warnings' cargo test --features pyo3,serde
 
 # Test documentation
 test-doc:

--- a/src/kwp2000/commands.rs
+++ b/src/kwp2000/commands.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
+python_test!(kwp2000, KwpCommand, StartDiagnosticSession, ECUReset);
 
 /// KWP Command Service IDs.
 ///
@@ -8,6 +11,7 @@ crate::utils::enum_wrapper!(kwp2000, KwpCommand, KwpCommandByte);
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum KwpCommand {
     /// Start or change ECU diagnostic session mode.

--- a/src/kwp2000/errors.rs
+++ b/src/kwp2000/errors.rs
@@ -1,10 +1,14 @@
-crate::utils::enum_wrapper!(kwp2000, KwpError, KwpErrorByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(kwp2000, KwpError, KwpErrorByte);
+python_test!(kwp2000, KwpError, GeneralReject, ServiceNotSupported);
 
 /// KWP2000 Error definitions
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum KwpError {
     /// ECU rejected the request for unknown reason

--- a/src/kwp2000/reset_types.rs
+++ b/src/kwp2000/reset_types.rs
@@ -1,6 +1,9 @@
 //! This service requests the ECU to perform a reset
 
-crate::utils::enum_wrapper!(kwp2000, ResetType, ResetTypeByte, display = @"157395241436022347");
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(kwp2000, ResetType, ResetTypeByte, display = @"157395241436022347");
+python_test!(kwp2000, ResetType, PowerOnReset, NonVolatileMemoryReset);
 
 /// ECU Reset types
 ///
@@ -15,6 +18,7 @@ crate::utils::enum_wrapper!(kwp2000, ResetType, ResetTypeByte, display = @"15739
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ResetType {
     /// Simulates a power off/on reset of the ECU.

--- a/src/kwp2000/routine_exit_status.rs
+++ b/src/kwp2000/routine_exit_status.rs
@@ -1,9 +1,18 @@
-crate::utils::enum_wrapper!(kwp2000, RoutineExitStatus, RoutineExitStatusByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(kwp2000, RoutineExitStatus, RoutineExitStatusByte);
+python_test!(
+    kwp2000,
+    RoutineExitStatus,
+    NormalExitWithResults,
+    AbnormalExitWithoutResults
+);
 
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::enum_variant_names)]
 pub enum RoutineExitStatus {

--- a/src/kwp2000/session_types.rs
+++ b/src/kwp2000/session_types.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
+python_test!(kwp2000, KwpSessionType, Normal, ExtendedDiagnostics);
 
 /// KWP2000 diagnostic session type
 ///
@@ -15,6 +18,7 @@ crate::utils::enum_wrapper!(kwp2000, KwpSessionType, KwpSessionTypeByte);
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum KwpSessionType {
     /// Normal session. The ECU will typically boot in this state.

--- a/src/obd2/command_2nd_air_status.rs
+++ b/src/obd2/command_2nd_air_status.rs
@@ -1,9 +1,12 @@
-crate::utils::enum_wrapper!(
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(
     obd2,
     CommandedSecondaryAirStatus,
     CommandedSecondaryAirStatusByte,
     display = @"4674215784794864501"
 );
+python_test!(obd2, CommandedSecondaryAirStatus, Upstream, DownstreamOfCat);
 
 /// Commanded secondary air status for PID 12
 #[repr(u8)]
@@ -11,6 +14,7 @@ crate::utils::enum_wrapper!(
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CommandedSecondaryAirStatus {
     /// Upstream

--- a/src/obd2/commands.rs
+++ b/src/obd2/commands.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(obd2, Obd2Command, Obd2CommandByte, display = @"200205385734257990");
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(obd2, Obd2Command, Obd2CommandByte, display = @"200205385734257990");
+python_test!(obd2, Obd2Command, Service01, Service02);
 
 /// OBD2 Command Service IDs
 #[repr(u8)]
@@ -6,6 +9,7 @@ crate::utils::enum_wrapper!(obd2, Obd2Command, Obd2CommandByte, display = @"2002
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Obd2Command {
     /// Service 01 - Show current data

--- a/src/obd2/data_pids.rs
+++ b/src/obd2/data_pids.rs
@@ -1,10 +1,14 @@
-crate::utils::enum_wrapper!(obd2, DataPid, DataPidByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(obd2, DataPid, DataPidByte);
+python_test!(obd2, DataPid, PidSupport0120, PidSupport6180);
 
 /// OBD2 data PIDs used for Service 01 and 02
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DataPid {
     PidSupport0120 = 0x00,

--- a/src/obd2/errors.rs
+++ b/src/obd2/errors.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte, display = @"5836240184362350709");
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte, display = @"5836240184362350709");
+python_test!(obd2, Obd2Error, GeneralReject, FormatIncorrect);
 
 /// OBD2 Error definitions
 #[repr(u8)]
@@ -6,6 +9,7 @@ crate::utils::enum_wrapper!(obd2, Obd2Error, Obd2ErrorByte, display = @"58362401
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Obd2Error {
     /// ECU general reject

--- a/src/obd2/fuel_system_status.rs
+++ b/src/obd2/fuel_system_status.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte, display = @"14417397174224904691");
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte, display = @"14417397174224904691");
+python_test!(obd2, FuelSystemStatus, Off, ClosedLoopO2Feedback);
 
 /// Fuel system status enumeration for PID 03
 #[repr(u8)]
@@ -6,6 +9,7 @@ crate::utils::enum_wrapper!(obd2, FuelSystemStatus, FuelSystemStatusByte, displa
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FuelSystemStatus {
     /// The motor is off

--- a/src/obd2/fuel_types.rs
+++ b/src/obd2/fuel_types.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte, display = @"8724297537048401983");
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte, display = @"8724297537048401983");
+python_test!(obd2, FuelTypeCoding, NotAvailable, Gasoline);
 
 /// Fuel type coding for PID 51
 #[allow(non_camel_case_types)]
@@ -7,6 +10,7 @@ crate::utils::enum_wrapper!(obd2, FuelTypeCoding, FuelTypeCodingByte, display = 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::upper_case_acronyms)]
 pub enum FuelTypeCoding {

--- a/src/obd2/obd_standard.rs
+++ b/src/obd2/obd_standard.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(obd2, ObdStandard, ObdStandardByte, display = @"16384231687073919054");
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(obd2, ObdStandard, ObdStandardByte, display = @"16384231687073919054");
+python_test!(obd2, ObdStandard, OBD_II_CARB, OBD_EPA);
 
 /// OBD Standard for PID 1C
 #[allow(non_camel_case_types)]
@@ -7,6 +10,7 @@ crate::utils::enum_wrapper!(obd2, ObdStandard, ObdStandardByte, display = @"1638
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::doc_markdown, clippy::upper_case_acronyms)]
 pub enum ObdStandard {

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(obd2, Service09Pid, Service09PidByte, display = @"7936397335745330157");
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(obd2, Service09Pid, Service09PidByte, display = @"7936397335745330157");
+python_test!(obd2, Service09Pid, VinMsgCount, Vin);
 
 /// OBD2 service 09 (Request vehicle information) PIDs
 #[repr(u8)]
@@ -6,6 +9,7 @@ crate::utils::enum_wrapper!(obd2, Service09Pid, Service09PidByte, display = @"79
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Service09Pid {
     /// VIN message count (Only for LIN)

--- a/src/uds/comm_level.rs
+++ b/src/uds/comm_level.rs
@@ -1,10 +1,14 @@
-crate::utils::enum_wrapper!(uds, CommunicationLevel, CommunicationLevelByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(uds, CommunicationLevel, CommunicationLevelByte);
+python_test!(uds, CommunicationLevel, EnableRxAndTx, EnableRxDisableTx);
 
 /// Communication level toggle
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CommunicationLevel {
     /// This value indicates that the reception and transmission of messages

--- a/src/uds/commands.rs
+++ b/src/uds/commands.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(uds, UdsCommand, UdsCommandByte, display = @"10111100423397497463");
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(uds, UdsCommand, UdsCommandByte, display = @"10111100423397497463");
+python_test!(uds, UdsCommand, DiagnosticSessionControl, ECUReset);
 
 /// UDS Command Service IDs
 #[repr(u8)]
@@ -6,6 +9,7 @@ crate::utils::enum_wrapper!(uds, UdsCommand, UdsCommandByte, display = @"1011110
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UdsCommand {
     /// The client requests to control a diagnostic session with a server(s).

--- a/src/uds/errors.rs
+++ b/src/uds/errors.rs
@@ -1,14 +1,16 @@
 #[cfg(doc)]
 use crate::uds::SecurityOperation;
-use crate::utils::enum_wrapper;
+use crate::utils::{enum_wrapper, python_test};
 
 enum_wrapper!(uds, UdsError, UdsErrorByte);
+python_test!(uds, UdsError, GeneralReject, ServiceNotSupported);
 
 /// UDS Error definitions
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UdsError {
     /// ECU rejected the request (No specific error)

--- a/src/uds/read_dtc_information.rs
+++ b/src/uds/read_dtc_information.rs
@@ -1,8 +1,14 @@
 #[cfg(doc)]
 use crate::uds::UdsCommand;
-use crate::utils::enum_wrapper;
+use crate::utils::{enum_wrapper, python_test};
 
 enum_wrapper!(uds, DtcSubFunction, DtcSubFunctionByte, display = @"10134386477669841736");
+python_test!(
+    uds,
+    DtcSubFunction,
+    ReportNumberOfDtcByStatusMask,
+    ReportDtcByStatusMask
+);
 
 /// [`UdsCommand::ReadDTCInformation`] sub-function definitions
 #[repr(u8)]
@@ -10,6 +16,7 @@ enum_wrapper!(uds, DtcSubFunction, DtcSubFunctionByte, display = @"1013438647766
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::doc_markdown, clippy::enum_variant_names)]
 pub enum DtcSubFunction {

--- a/src/uds/reset_types.rs
+++ b/src/uds/reset_types.rs
@@ -1,10 +1,14 @@
-crate::utils::enum_wrapper!(uds, ResetType, ResetTypeByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(uds, ResetType, ResetTypeByte);
+python_test!(uds, ResetType, HardReset, SoftReset);
 
 /// Reset ECU subcommand
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ResetType {
     /// Signals the ECU to perform a hard-reset,

--- a/src/uds/routine.rs
+++ b/src/uds/routine.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
+python_test!(uds, RoutineControlType, StartRoutine, StopRoutine);
 
 /// UDS Routine (0x31) service control types.
 /// See chapter `14.2 RoutineControl service` in the ISO 14229 spec.
@@ -6,6 +9,7 @@ crate::utils::enum_wrapper!(uds, RoutineControlType, RoutineControlTypeByte);
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum RoutineControlType {
     /// Launches a routine on the ECU

--- a/src/uds/scaling_byte.rs
+++ b/src/uds/scaling_byte.rs
@@ -1,5 +1,8 @@
-crate::utils::enum_byte_wrapper!(uds, Scaling, ScalingByte);
-crate::utils::enum_impls!(uds, ScalingType, u8);
+use crate::utils::{enum_byte_wrapper, enum_impls, python_test};
+
+enum_byte_wrapper!(uds, Scaling, ScalingByte);
+enum_impls!(uds, ScalingType, u8);
+python_test!(uds, ScalingType, Bcd, Ascii);
 
 /// Scaling high nibble, representing the type of data without its size. The size is given by the low nibble.
 #[repr(u8)]
@@ -7,6 +10,7 @@ crate::utils::enum_impls!(uds, ScalingType, u8);
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ScalingType {
     /// Unsigned numeric integer. Must be followed by 1..4 bytes, given as a low nibble of the byte.
@@ -38,6 +42,7 @@ pub enum ScalingType {
 /// Scaling value with both the [`ScalingType`] and the size of the data.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Scaling {
     typ: ScalingType,

--- a/src/uds/scaling_byte_ext.rs
+++ b/src/uds/scaling_byte_ext.rs
@@ -1,4 +1,7 @@
-crate::utils::enum_wrapper!(uds, ScalingExtension, ScalingExtensionByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(uds, ScalingExtension, ScalingExtensionByte);
+python_test!(uds, ScalingExtension, NoUnit, Meter);
 
 /// A macro rule to generate prefix and postfix functions from a single enum
 macro_rules! generate_enum {
@@ -64,7 +67,8 @@ generate_enum! {
     #[repr(u8)]
     #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub enum ScalingExtension {
         /// No unit or presentation
         NoUnit = 0x00,

--- a/src/uds/security_access.rs
+++ b/src/uds/security_access.rs
@@ -3,13 +3,17 @@
 //!
 //! Currently, only default seed/key (0x01/0x02) are supported
 
-crate::utils::enum_wrapper!(uds, SecurityOperation, SecurityOperationByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(uds, SecurityOperation, SecurityOperationByte);
+python_test!(uds, SecurityOperation, RequestSeed, SendKey);
 
 /// Security operation request
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SecurityOperation {
     /// Asks the ECU for a security seed

--- a/src/uds/session_types.rs
+++ b/src/uds/session_types.rs
@@ -1,10 +1,14 @@
-crate::utils::enum_wrapper!(uds, UdsSessionType, UdsSessionTypeByte);
+use crate::utils::{enum_wrapper, python_test};
+
+enum_wrapper!(uds, UdsSessionType, UdsSessionTypeByte);
+python_test!(uds, UdsSessionType, Default, Programming);
 
 /// UDS Diagnostic session modes. Handled by SID 0x10
 #[repr(u8)]
 #[derive(strum::FromRepr, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UdsSessionType {
     /// Default diagnostic session mode (ECU is normally in this mode on startup)


### PR DESCRIPTION
Adds a feature `pyo3` that supports using enum values from Python