### PR TITLE
Fix serde usage for no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automotive_diag"
-version = "0.1.15"
+version = "0.1.16"
 description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330), OBD-II (ISO-9141), and DoIP (ISO-13400) definitions to communicate with the road vehicle ECUs in Rust."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "Ashcon Mohseninia <ashconm@outlook.com>"]
 repository = "https://github.com/nyurik/automotive_diag"
@@ -13,7 +13,7 @@ rust-version = "1.70"
 [features]
 default = ["std", "iter", "display", "kwp2000", "obd2", "uds"]
 # Include support for std library. Without this feature, uses `no_std` attribute
-std = ["strum/default"]
+std = ["strum/default", "serde?/default"]
 # Add support for `defmt` logging
 defmt = ["dep:defmt"]
 # Add Display trait for all enums, using doc comments as display strings. Requires `std`.
@@ -24,7 +24,7 @@ iter = []
 pyo3 = ["std", "dep:pyo3"]
 # Include support for serde serialization
 serde = ["dep:serde"]
-# Include support for DoIP - ISO-13400. This feature is unstable, and is not enabled by default.
+# Include support for DoIP - ISO-13400. This feature is unstable and is not enabled by default.
 doip = []
 # Include support for Keyword protocol 2000 - ISO-142330
 kwp2000 = []
@@ -39,7 +39,7 @@ with-uds = ["uds"] # deprecated, use `uds` instead
 [dependencies]
 defmt = { version = "1.0.1", optional = true }
 displaydoc = { version = "0.2", optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
 strum = { version = "0.27.0", default-features = false, features = ["derive"] }
 pyo3 = { version = "0.25.0", optional = true }
 

--- a/justfile
+++ b/justfile
@@ -79,13 +79,17 @@ ci-coverage: && \
 
 # Run all tests
 test:
+    # Ensure std is only enabled in serde when expected
+    cargo tree --invert serde --format '{p} {f}' --depth 0 --edges normal --no-default-features --features serde | tee /dev/stderr | grep std \
+      && echo 'std is enabled in serde in non-default mode' && exit 1 || echo 'std is not enabled as expected'
+    cargo tree --invert serde --format '{p} {f}' --depth 0 --edges normal --features serde | tee /dev/stderr | grep -v std \
+      && echo 'std is not enabled in serde in default mode' && exit 1 || echo 'std is enabled as expected'
     RUSTFLAGS='-D warnings' cargo test --workspace --all-targets --all-features
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features kwp2000
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features obd2
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features uds
     RUSTFLAGS='-D warnings' cargo test --no-default-features --features doip
-    RUSTFLAGS='-D warnings' cargo test --no-default-features --features defmt,iter,doip,uds,obd2,kwp2000
-    RUSTFLAGS='-D warnings' cargo test --features serde
+    RUSTFLAGS='-D warnings' cargo test --no-default-features --features defmt,iter,serde,doip,uds,obd2,kwp2000
     RUSTFLAGS='-D warnings' cargo test --features pyo3
     RUSTFLAGS='-D warnings' cargo test --features pyo3,serde
 


### PR DESCRIPTION
When used in the `no_std` mode (default features disabled), switch `serde` to the no_std mode as well.