### PR TITLE
Allow display to be used in no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automotive_diag"
-version = "0.1.16"
+version = "0.1.17"
 description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330), OBD-II (ISO-9141), and DoIP (ISO-13400) definitions to communicate with the road vehicle ECUs in Rust."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "Ashcon Mohseninia <ashconm@outlook.com>"]
 repository = "https://github.com/nyurik/automotive_diag"
@@ -13,11 +13,11 @@ rust-version = "1.70"
 [features]
 default = ["std", "iter", "display", "kwp2000", "obd2", "uds"]
 # Include support for std library. Without this feature, uses `no_std` attribute
-std = ["strum/default", "serde?/default"]
+std = ["displaydoc?/default", "serde?/default", "strum/default"]
 # Add support for `defmt` logging
 defmt = ["dep:defmt"]
-# Add Display trait for all enums, using doc comments as display strings. Requires `std`.
-display = ["std", "dep:displaydoc"]
+# Add Display trait for all enums, using doc comments as display strings.
+display = ["dep:displaydoc"]
 # Add Enum::iter() implementation for all enums
 iter = []
 # Generate Python bindings for enums using pyo3. Requires std.
@@ -38,7 +38,7 @@ with-uds = ["uds"] # deprecated, use `uds` instead
 
 [dependencies]
 defmt = { version = "1.0.1", optional = true }
-displaydoc = { version = "0.2", optional = true }
+displaydoc = { version = "0.2", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
 strum = { version = "0.27.0", default-features = false, features = ["derive"] }
 pyo3 = { version = "0.25.0", optional = true }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -175,7 +175,7 @@ macro_rules! python_test {
 }
 
 /// Compute the combined value of all `Display` representations of all enum variants for hashing purposes.
-#[cfg(all(test, feature = "iter", feature = "display"))]
+#[cfg(all(test, feature = "std", feature = "iter", feature = "display"))]
 pub(crate) fn calc_display_hash<T: strum::IntoEnumIterator + std::fmt::Display>() -> u64 {
     use std::hash::Hasher as _;
 
@@ -189,7 +189,7 @@ pub(crate) fn calc_display_hash<T: strum::IntoEnumIterator + std::fmt::Display>(
 /// Assert that the display hash of an enum matches the expected value.
 macro_rules! assert_display_hash {
     ($enm:ty, $($arg:tt)*) => {
-        #[cfg(all(test, feature = "iter", feature = "display"))]
+        #[cfg(all(test, feature = "std", feature = "iter", feature = "display"))]
         mod display_hash_tests {
             use super::*;
             use insta::assert_debug_snapshot;


### PR DESCRIPTION
**MINOR BREAKING**: `display` feature will no longer auto-enable `std` feature

When used in the `no_std` mode (default features disabled), switch `displaydoc` dependency to the no_std mode as well.