### PR TITLE
chore: release v0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/nyurik/automotive_diag/compare/v0.1.19...v0.1.20) - 2025-06-08
+
+### Other
+
+- remove default ci perms
+- update deps on release
+
 ## [0.1.19](https://github.com/nyurik/automotive_diag/compare/v0.1.18...v0.1.19) - 2025-06-08
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automotive_diag"
-version = "0.1.19"
+version = "0.1.20"
 description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330), OBD-II (ISO-9141), and DoIP (ISO-13400) definitions to communicate with the road vehicle ECUs in Rust."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "Ashcon Mohseninia <ashconm@outlook.com>"]
 repository = "https://github.com/nyurik/automotive_diag"


### PR DESCRIPTION



## 🤖 New release

* `automotive_diag`: 0.1.19 -> 0.1.20 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.20](https://github.com/nyurik/automotive_diag/compare/v0.1.19...v0.1.20) - 2025-06-08

### Other

- remove default ci perms
- update deps on release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).