### PR TITLE
chore: release v0.1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/nyurik/automotive_diag/compare/v0.1.22...v0.1.23) - 2025-08-16
+
+### Other
+
+- *(ci)* format dependabot.yml
+
 ## [0.1.22](https://github.com/nyurik/automotive_diag/compare/v0.1.21...v0.1.22) - 2025-08-16
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automotive_diag"
-version = "0.1.22"
+version = "0.1.23"
 description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330), OBD-II (ISO-9141), and DoIP (ISO-13400) definitions to communicate with the road vehicle ECUs in Rust."
 authors = [
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `automotive_diag`: 0.1.22 -> 0.1.23 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.23](https://github.com/nyurik/automotive_diag/compare/v0.1.22...v0.1.23) - 2025-08-16

### Other

- *(ci)* format dependabot.yml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).