### PR TITLE
chore: release v0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28](https://github.com/oxibus/automotive_diag/compare/v0.1.27...v0.1.28) - 2026-04-15
+
+### Added
+
+- add several new UDS enums ([#85](https://github.com/oxibus/automotive_diag/pull/85))
+- add UDS `AuthenticationSubFunction` enum  ([#84](https://github.com/oxibus/automotive_diag/pull/84))
+
+### Other
+
+- *(deps)* bump dependabot/fetch-metadata from 2 to 3 in the all-actions-version-updates group ([#83](https://github.com/oxibus/automotive_diag/pull/83))
+- use only first doc str for Display impl ([#86](https://github.com/oxibus/automotive_diag/pull/86))
+- *(deps)* bump codecov/codecov-action from 5 to 6 in the all-actions-version-updates group ([#82](https://github.com/oxibus/automotive_diag/pull/82))
+- *(deps)* bump the all-cargo-version-updates group across 1 directory with 2 updates ([#76](https://github.com/oxibus/automotive_diag/pull/76))
+- [pre-commit.ci] pre-commit autoupdate ([#78](https://github.com/oxibus/automotive_diag/pull/78))
+
 ## [0.1.27](https://github.com/oxibus/automotive_diag/compare/v0.1.26...v0.1.27) - 2026-03-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automotive_diag"
-version = "0.1.27"
+version = "0.1.28"
 description = "Unified Diagnostic Services/UDS (ISO-14229-1), KWP2000 (ISO-142330), OBD-II (ISO-9141), and DoIP (ISO-13400) definitions to communicate with the road vehicle ECUs in Rust."
 authors = [
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `automotive_diag`: 0.1.27 -> 0.1.28 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.28](https://github.com/oxibus/automotive_diag/compare/v0.1.27...v0.1.28) - 2026-04-15

### Added

- add several new UDS enums ([#85](https://github.com/oxibus/automotive_diag/pull/85))
- add UDS `AuthenticationSubFunction` enum  ([#84](https://github.com/oxibus/automotive_diag/pull/84))

### Other

- *(deps)* bump dependabot/fetch-metadata from 2 to 3 in the all-actions-version-updates group ([#83](https://github.com/oxibus/automotive_diag/pull/83))
- use only first doc str for Display impl ([#86](https://github.com/oxibus/automotive_diag/pull/86))
- *(deps)* bump codecov/codecov-action from 5 to 6 in the all-actions-version-updates group ([#82](https://github.com/oxibus/automotive_diag/pull/82))
- *(deps)* bump the all-cargo-version-updates group across 1 directory with 2 updates ([#76](https://github.com/oxibus/automotive_diag/pull/76))
- [pre-commit.ci] pre-commit autoupdate ([#78](https://github.com/oxibus/automotive_diag/pull/78))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).