### PR TITLE
chore: use only first doc str for Display impl

### DIFF
--- a/src/doip/action_code.rs
+++ b/src/doip/action_code.rs
@@ -18,6 +18,7 @@ python_test!(
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/activation_code.rs
+++ b/src/doip/activation_code.rs
@@ -19,6 +19,7 @@ python_test!(
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/activation_type.rs
+++ b/src/doip/activation_type.rs
@@ -13,6 +13,7 @@ python_test!(doip, ActivationType, Default, WwhObd);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/diagnostic_ack.rs
+++ b/src/doip/diagnostic_ack.rs
@@ -12,6 +12,7 @@ python_test!(doip, DiagnosticAckCode, Acknowledged);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/diagnostic_nack.rs
+++ b/src/doip/diagnostic_nack.rs
@@ -17,6 +17,7 @@ python_test!(
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/nack_code.rs
+++ b/src/doip/nack_code.rs
@@ -12,6 +12,7 @@ python_test!(doip, NackCode, IncorrectPatternFormat, UnknownPayloadType);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/node_type.rs
+++ b/src/doip/node_type.rs
@@ -13,6 +13,7 @@ python_test!(doip, NodeType, DoIpGateway, DoIpNode);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/payload_type.rs
+++ b/src/doip/payload_type.rs
@@ -14,6 +14,7 @@ python_test!(doip, PayloadType, GenericNack, VehicleIdentificationRequest);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/power_mode.rs
+++ b/src/doip/power_mode.rs
@@ -11,6 +11,7 @@ python_test!(doip, PowerMode, NotReady, Ready);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/protocol_version.rs
+++ b/src/doip/protocol_version.rs
@@ -17,6 +17,7 @@ python_test!(doip, ProtocolVersion, V2010, V2012);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/doip/sync_status.rs
+++ b/src/doip/sync_status.rs
@@ -13,6 +13,7 @@ python_test!(doip, SyncStatus, VinGidSynchronized, VinGidNotSynchronized);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/kwp2000/reset_types.rs
+++ b/src/kwp2000/reset_types.rs
@@ -19,6 +19,7 @@ python_test!(kwp2000, ResetType, PowerOnReset, NonVolatileMemoryReset);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/obd2/command_2nd_air_status.rs
+++ b/src/obd2/command_2nd_air_status.rs
@@ -15,6 +15,7 @@ python_test!(obd2, CommandedSecondaryAirStatus, Upstream, DownstreamOfCat);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/obd2/commands.rs
+++ b/src/obd2/commands.rs
@@ -10,6 +10,7 @@ python_test!(obd2, Obd2Command, Service01, Service02);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/obd2/errors.rs
+++ b/src/obd2/errors.rs
@@ -10,6 +10,7 @@ python_test!(obd2, Obd2Error, GeneralReject, FormatIncorrect);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/obd2/fuel_system_status.rs
+++ b/src/obd2/fuel_system_status.rs
@@ -10,6 +10,7 @@ python_test!(obd2, FuelSystemStatus, Off, ClosedLoopO2Feedback);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/obd2/fuel_types.rs
+++ b/src/obd2/fuel_types.rs
@@ -11,6 +11,7 @@ python_test!(obd2, FuelTypeCoding, NotAvailable, Gasoline);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/obd2/obd_standard.rs
+++ b/src/obd2/obd_standard.rs
@@ -11,6 +11,7 @@ python_test!(obd2, ObdStandard, OBD_II_CARB, OBD_EPA);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -10,6 +10,7 @@ python_test!(obd2, Service09Pid, VinMsgCount, Vin);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -28,7 +29,7 @@ pub enum Service09Pid {
     Cvn = 0x06,
     /// In use performance tracking for spark ignition engines
     InUsePerfTracking = 0x08,
-    ///ECU name message count (Only for LIN)
+    /// ECU name message count (Only for LIN)
     EcuNameMsgCount = 0x09,
     /// ECU name
     EcuName = 0x0A,

--- a/src/uds/comm_control.rs
+++ b/src/uds/comm_control.rs
@@ -2,6 +2,7 @@
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 pub enum CommunicationType {
     /// Application layer communication (inter-signal exchanges) between ECUs
     NormalCommunication,
@@ -15,6 +16,7 @@ pub enum CommunicationType {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 pub enum Subnet {
     /// All subnets
     All,

--- a/src/uds/commands.rs
+++ b/src/uds/commands.rs
@@ -10,6 +10,7 @@ python_test!(uds, UdsCommand, DiagnosticSessionControl, ECUReset);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -52,11 +53,11 @@ pub enum UdsCommand {
     ClearDiagnosticInformation = 0x14,
     /// Allows the client to request diagnostic information from the server (including DTCs, captured data, etc.).
     ReadDTCInformation = 0x19,
-    ///The client requests the control of an input/output specific to the server.
+    /// The client requests the control of an input/output specific to the server.
     InputOutputControlByIdentifier = 0x2F,
     /// The client requests to start, stop a routine in the server(s) or requests the routine results. See also [`crate::uds::RoutineControlType`].
     RoutineControl = 0x31,
-    ///The client requests the negotiation of a data transfer from the client to the server.
+    /// The client requests the negotiation of a data transfer from the client to the server.
     RequestDownload = 0x34,
     /// The client requests the negotiation of a data transfer from the server to the client.
     RequestUpload = 0x35,

--- a/src/uds/read_dtc_information.rs
+++ b/src/uds/read_dtc_information.rs
@@ -17,6 +17,7 @@ python_test!(
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/uds/scaling_byte.rs
+++ b/src/uds/scaling_byte.rs
@@ -11,6 +11,7 @@ python_test!(uds, ScalingType, Bcd, Ascii);
 #[cfg_attr(feature = "bin-proto", derive(bin_proto::BitDecode))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "display", derive(displaydoc::Display))]
+#[cfg_attr(feature = "display", ignore_extra_doc_attributes)]
 #[cfg_attr(feature = "iter", derive(strum::EnumIter))]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int, from_py_object))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
This is mostly a noop, but allows additional doc strings to be added for documentation, but ignored in the Display impl.